### PR TITLE
fix: search error due to timeout

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1917,7 +1917,7 @@ RAG_WEB_SEARCH_RESULT_COUNT = PersistentConfig(
 RAG_WEB_SEARCH_CONCURRENT_REQUESTS = PersistentConfig(
     "RAG_WEB_SEARCH_CONCURRENT_REQUESTS",
     "rag.web.search.concurrent_requests",
-    int(os.getenv("RAG_WEB_SEARCH_CONCURRENT_REQUESTS", "10")),
+    int(os.getenv("RAG_WEB_SEARCH_CONCURRENT_REQUESTS", "20")),
 )
 
 RAG_WEB_SEARCH_TRUST_ENV = PersistentConfig(

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -87,7 +87,10 @@ class SafeWebBaseLoader(WebBaseLoader):
     async def _fetch(
         self, url: str, retries: int = 1, cooldown: int = 2, backoff: float = 1.5
     ) -> str:
-        async with aiohttp.ClientSession(trust_env=self.trust_env) as session:
+        timeout = aiohttp.ClientTimeout(total=2)
+        async with aiohttp.ClientSession(
+            trust_env=self.trust_env, timeout=timeout
+        ) as session:
             for i in range(retries):
                 try:
                     kwargs: Dict = dict(
@@ -201,9 +204,10 @@ class SafeWebBaseLoader(WebBaseLoader):
 def get_web_loader(
     urls: Union[str, Sequence[str]],
     verify_ssl: bool = True,
-    requests_per_second: int = 2,
+    requests_per_second: int = 20,
     trust_env: bool = True,
 ):
+    log.info(f"trust_env: {trust_env}; requests_per_second: {requests_per_second}")
     # Check if the URLs are valid
     safe_urls = safe_validate_urls([urls] if isinstance(urls, str) else urls)
 

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -99,9 +99,7 @@ class SafeWebBaseLoader(WebBaseLoader):
                         if self.raise_for_status:
                             response.raise_for_status()
                         content = await response.text()
-                        log.info(
-                            f"Successfully fetched {url}, content : {content[:100]}"
-                        )
+                        log.info(f"Successfully fetched {url}")
                         return content
                 except aiohttp.ClientConnectionError as e:
                     if i == retries - 1:
@@ -111,7 +109,7 @@ class SafeWebBaseLoader(WebBaseLoader):
                             f"Error fetching {url} with attempt "
                             f"{i + 1}/{retries}: {e}. Retrying..."
                         )
-                        await asyncio.sleep(cooldown * backoff**i)
+                        # await asyncio.sleep(cooldown * backoff**i)
                 except Exception as e:
                     log.error(f"Error fetching {url}: {e}")
                     raise
@@ -202,7 +200,6 @@ def get_web_loader(
     requests_per_second: int = 2,
     trust_env: bool = True,
 ):
-    log.info(f"trust_env: {trust_env}")
     # Check if the URLs are valid
     safe_urls = safe_validate_urls([urls] if isinstance(urls, str) else urls)
 

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -185,6 +185,7 @@ def get_web_loader(
     requests_per_second: int = 2,
     trust_env: bool = True,
 ):
+    log.info(f"trust_env: {trust_env}")
     # Check if the URLs are valid
     safe_urls = safe_validate_urls([urls] if isinstance(urls, str) else urls)
 

--- a/backend/open_webui/retrieval/web/utils.py
+++ b/backend/open_webui/retrieval/web/utils.py
@@ -59,7 +59,11 @@ def safe_validate_urls(url: Sequence[str]) -> Sequence[str]:
 
 def resolve_hostname(hostname):
     # Get address information
-    addr_info = socket.getaddrinfo(hostname, None)
+    try:
+        addr_info = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        log.error(f"Error resolving hostname {hostname}: {e}")
+        return [], []
 
     # Extract IP addresses from address information
     ipv4_addresses = [info[4][0] for info in addr_info if info[0] == socket.AF_INET]

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1355,7 +1355,7 @@ async def process_web_search(
             urls,
             verify_ssl=request.app.state.config.ENABLE_RAG_WEB_LOADER_SSL_VERIFICATION,
             requests_per_second=request.app.state.config.RAG_WEB_SEARCH_CONCURRENT_REQUESTS,
-            trust_env=request.app.state.config.RAG_WEB_SEARCH_TRUST_ENV,
+            trust_env=True,
         )
         docs = await loader.aload()
 

--- a/nginx/test/gpt-oi-web/nginx.conf
+++ b/nginx/test/gpt-oi-web/nginx.conf
@@ -64,6 +64,15 @@ http {
             proxy_http_version 1.1;
             client_body_buffer_size 128k;
             proxy_pass http://10.10.1.118:9090;
+
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header Connection "Upgrade";
+
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_read_timeout 3600s;
         }
 
         location /ollama {
@@ -82,6 +91,10 @@ http {
             proxy_set_header Host $host;
             proxy_set_header Connection "Upgrade";
             proxy_pass http://10.10.1.118:9090;
+
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         error_page 404 /404.html;

--- a/nginx/test/gpt-oi-web/nginx.conf
+++ b/nginx/test/gpt-oi-web/nginx.conf
@@ -46,6 +46,17 @@ http {
             root /app/gpt-oi-web/web;
             try_files $uri $uri/ /index.html;
 
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header Connection "Upgrade";
+            proxy_pass http://10.10.1.118:9090;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+
             add_header Access-Control-Allow-Origin *;
             add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS';
             add_header Access-Control-Allow-Headers 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
@@ -82,6 +93,11 @@ http {
             proxy_set_header Host $host;
             proxy_set_header Connection "Upgrade";
             proxy_pass http://10.10.1.118:9090;
+
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         error_page 404 /404.html;

--- a/nginx/test/gpt-oi-web/nginx.conf
+++ b/nginx/test/gpt-oi-web/nginx.conf
@@ -46,17 +46,6 @@ http {
             root /app/gpt-oi-web/web;
             try_files $uri $uri/ /index.html;
 
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Host $host;
-            proxy_set_header Connection "Upgrade";
-            proxy_pass http://10.10.1.118:9090;
-
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-
             add_header Access-Control-Allow-Origin *;
             add_header Access-Control-Allow-Methods 'GET, POST, OPTIONS';
             add_header Access-Control-Allow-Headers 'DNT,X-Mx-ReqToken,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization';
@@ -93,11 +82,6 @@ http {
             proxy_set_header Host $host;
             proxy_set_header Connection "Upgrade";
             proxy_pass http://10.10.1.118:9090;
-
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
         error_page 404 /404.html;

--- a/src/lib/components/chat/Messages/Error.svelte
+++ b/src/lib/components/chat/Messages/Error.svelte
@@ -10,8 +10,6 @@
 	</div>
 
 	<div class=" self-center text-sm">
-		{console.log('Rendered content:', content)}
-		<!-- content 不为 json 的处理补全 -->
-		{typeof content === 'string' ? content : (c=>{try{return JSON.stringify(c,(k,v)=>v===undefined?'undefined':v instanceof Node?'[Node]':typeof v==='function'?'[Function]':v)}catch(e){return`[Serialization Error: ${e.message}]`}})(content)}
+		{typeof content === 'string' ? content : JSON.stringify(content)}
 	</div>
 </div>

--- a/src/lib/components/chat/Messages/Error.svelte
+++ b/src/lib/components/chat/Messages/Error.svelte
@@ -10,6 +10,8 @@
 	</div>
 
 	<div class=" self-center text-sm">
-		{typeof content === 'string' ? content : JSON.stringify(content)}
+		{console.log('Rendered content:', content)}
+		<!-- content 不为 json 的处理补全 -->
+		{typeof content === 'string' ? content : (c=>{try{return JSON.stringify(c,(k,v)=>v===undefined?'undefined':v instanceof Node?'[Node]':typeof v==='function'?'[Function]':v)}catch(e){return`[Serialization Error: ${e.message}]`}})(content)}
 	</div>
 </div>


### PR DESCRIPTION
# Changelog Entry

### Description
问题：
- 访问后端 api 时，前端通过 nginx 访问，nginx 未设置超时时间，后端仍在处理中而 nginx 直接响应前端 404，后端处理完毕后返回 200，流式响应正常展示，但由于 nginx 返回 404，前端弹窗报错

解决：
- nginx 设置超时时间
- 搜索设置超时时间，之后再看看代理相关的影响，看看具体影响搜索超时/失败的原因